### PR TITLE
grub-efi: remove all .module

### DIFF
--- a/recipes-bsp/grub/grub-efi_2.00.bbappend
+++ b/recipes-bsp/grub/grub-efi_2.00.bbappend
@@ -39,6 +39,9 @@ do_install_append_class-target() {
 	# Install the modules to grub-efi's search path
 	make -C grub-core install DESTDIR=${D}${EFI_BOOT_PATH} pkglibdir=""
 
+	# Remove .module
+	rm -f ${D}${EFI_BOOT_PATH}/${GRUB_TARGET}-efi/*.module
+
 	# Generate startup.nsh, we have the boot info in GRUB_IMAGE, the
 	# startup.nsh is only used for running GRUB_IMAGE.
 cat > ${D}/boot/efi/startup.nsh <<_EOF


### PR DESCRIPTION
.mod is stripped from .module which should not be installed.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>